### PR TITLE
fix: downgrade node version to fix spawn error

### DIFF
--- a/nitro/Dockerfile
+++ b/nitro/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:20.2.0-alpine3.18
 
 WORKDIR /app
 


### PR DESCRIPTION
![Captura de tela de 2024-01-13 23-48-15](https://github.com/Holo5/nitro-docker/assets/83927877/76bab420-9b3d-4a7e-b202-c68dda8185af)

This spawn error is caused because of the error "env: can’t execute ‘node’: Text file busy" when nitro build.sh script tries to run yarn install.

I found the solution [here](https://forums.docker.com/t/getting-error-when-running-container-env-cant-execute-node-text-file-busy/136409);

Closes #13